### PR TITLE
Modularize rule extraction pipeline

### DIFF
--- a/example_pipeline.py
+++ b/example_pipeline.py
@@ -1,0 +1,82 @@
+"""Example pipeline demonstrating rule extraction and combination."""
+
+import lightgbm as lgb
+from sklearn.metrics import precision_score, recall_score, f1_score
+
+from pm_rules.config import RANDOM_STATE, PLOT_RULE_PERFORMANCE, POS_LABEL, MIN_SUPPORT, MIN_PRECISION, MIN_RECALL, MIN_F1
+from pm_rules.data import load_breast_cancer_split
+from pm_rules.rule_generation import extract_local_rules, extract_global_rules, merge_rule_sets
+from pm_rules.fsrs import fsrs_shorten_rule_row
+from pm_rules.classifiers import VotingRulesetClassifier
+from pm_rules.plotting import generate_rules_performance_report
+from pm_rules.utils import rule_to_string, rule_to_mask, rule_recall_global, f1_from_pr
+
+# Load data
+X_train, X_val, X_test, y_train, y_val, y_test = load_breast_cancer_split()
+
+# Train LightGBM
+clf = lgb.LGBMClassifier(
+    n_estimators=200,
+    max_depth=-1,
+    learning_rate=0.05,
+    num_leaves=31,
+    subsample=0.9,
+    colsample_bytree=0.9,
+    reg_lambda=1.0,
+    random_state=RANDOM_STATE,
+)
+clf.fit(X_train, y_train)
+
+# Quick sanity metrics
+y_pred = clf.predict(X_test)
+print({
+    "precision": precision_score(y_test, y_pred),
+    "recall": recall_score(y_test, y_pred),
+    "f1": f1_score(y_test, y_pred),
+})
+
+# Stage A: rule generation
+local_df = extract_local_rules(clf, X_val, y_val)
+global_df = extract_global_rules(clf, X_val, y_val)
+merged = merge_rule_sets(local_df, global_df)
+
+# Stage B: FSRS shortening
+fsrs_df = merged.copy().reset_index(drop=True)
+new_rule_dicts = []
+for _, row in fsrs_df.iterrows():
+    new_rd, diag = fsrs_shorten_rule_row(
+        rule_row=row,
+        X_val=X_val,
+        y_val=y_val,
+        pos_label=POS_LABEL,
+        min_covered=MIN_SUPPORT,
+    )
+    new_rule_dicts.append(new_rd)
+    row["fsrs_diag"] = diag
+fsrs_df["rule_dict"] = new_rule_dicts
+fsrs_df["rule_str"] = fsrs_df["rule_dict"].apply(rule_to_string)
+
+# Re-score rules after FSRS
+supports, ppvs, recs, f1s = [], [], [], []
+for rd in fsrs_df["rule_dict"]:
+    mask = rule_to_mask(rd, X_val)
+    support = int(mask.sum())
+    ppv = float((y_val[mask] == POS_LABEL).mean()) if support > 0 else 0.0
+    rec = rule_recall_global(mask, y_val, POS_LABEL)
+    f1 = f1_from_pr(ppv, rec)
+    supports.append(support); ppvs.append(ppv); recs.append(rec); f1s.append(f1)
+fsrs_df["support"] = supports
+fsrs_df["precision"] = ppvs
+fsrs_df["recall"] = recs
+fsrs_df["f1"] = f1s
+fsrs_df = fsrs_df[(fsrs_df["support"] >= MIN_SUPPORT) & (fsrs_df["precision"] >= MIN_PRECISION) & (fsrs_df["recall"] >= MIN_RECALL) & (fsrs_df["f1"] >= MIN_F1)].reset_index(drop=True)
+
+# Stage C: simple voting combiner
+fsrs_df = fsrs_df.sort_values(["f1", "precision", "support"], ascending=[False, False, False]).reset_index(drop=True)
+voter = VotingRulesetClassifier(fsrs_df)
+voter.fit(X_val, y_val)
+print("Validation metrics:", voter.evaluate(X_val, y_val))
+print("Test metrics:", voter.evaluate(X_test, y_test))
+
+if PLOT_RULE_PERFORMANCE:
+    generate_rules_performance_report(merged, "generated_rules_performances.pdf", min_precision=0.9, min_recall=0.15)

--- a/pm_rules/__init__.py
+++ b/pm_rules/__init__.py
@@ -1,0 +1,21 @@
+"""Utilities for mining high-precision rules from tree ensembles."""
+
+from .config import (
+    TOP_K_FEATURES_PER_INSTANCE,
+    MIN_SUPPORT,
+    MIN_PRECISION,
+    MIN_RECALL,
+    MIN_F1,
+    POS_LABEL,
+    RANDOM_STATE,
+)
+
+__all__ = [
+    "TOP_K_FEATURES_PER_INSTANCE",
+    "MIN_SUPPORT",
+    "MIN_PRECISION",
+    "MIN_RECALL",
+    "MIN_F1",
+    "POS_LABEL",
+    "RANDOM_STATE",
+]

--- a/pm_rules/classifiers.py
+++ b/pm_rules/classifiers.py
@@ -1,0 +1,159 @@
+"""Rule-based ensemble classifiers."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+import numpy as np
+import pandas as pd
+from sklearn.metrics import precision_score, recall_score, f1_score, roc_auc_score, average_precision_score
+from sklearn.linear_model import LogisticRegressionCV
+
+from .utils import rule_to_mask
+
+
+def _sigmoid(z: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+def _build_rule_matrix(rules_df: pd.DataFrame, X: pd.DataFrame) -> np.ndarray:
+    masks = []
+    for _, row in rules_df.iterrows():
+        rd = row.get("rule_dict") or {}
+        mask = rule_to_mask(rd, X) if rd else np.ones(len(X), dtype=bool)
+        masks.append(mask.astype(np.float32))
+    return np.vstack(masks)
+
+
+def _pick_threshold_for_f1(y_true: np.ndarray, y_prob: np.ndarray) -> Tuple[float, float, float, float]:
+    uniq = np.unique(np.round(y_prob, 6))
+    grid = np.linspace(0.05, 0.95, 19)
+    cand = np.unique(np.concatenate([uniq, grid]))
+    best = (0.5, 0.0, 0.0, 0.0)
+    for t in cand:
+        y_hat = (y_prob >= t).astype(int)
+        P = precision_score(y_true, y_hat, zero_division=0)
+        R = recall_score(y_true, y_hat, zero_division=0)
+        F = f1_score(y_true, y_hat, zero_division=0)
+        if F > best[3]:
+            best = (float(t), float(P), float(R), float(F))
+    return best
+
+
+class VotingRulesetClassifier:
+    """Combine rules via weighted voting with a tuned threshold."""
+
+    def __init__(self, rules_df: pd.DataFrame, weighting: str = "precision_logit"):
+        self.rules_df = rules_df.copy()
+        self.weighting = weighting
+        self.betas_: Optional[np.ndarray] = None
+        self.threshold_: Optional[float] = None
+
+    def _compute_betas(self) -> np.ndarray:
+        if self.weighting == "precision_logit":
+            p = np.clip(self.rules_df["precision"].to_numpy(float), 1e-3, 1 - 1e-3)
+            return np.log(p / (1 - p))
+        if self.weighting == "leaf_value":
+            return self.rules_df["leaf_value"].to_numpy(float)
+        if self.weighting == "uniform":
+            return np.ones(len(self.rules_df))
+        raise ValueError(f"Unknown weighting: {self.weighting}")
+
+    def fit(self, X_val: pd.DataFrame, y_val: pd.Series) -> "VotingRulesetClassifier":
+        M_val = _build_rule_matrix(self.rules_df, X_val)
+        betas = self._compute_betas()
+        z_val = (betas.reshape(-1, 1) * M_val).sum(axis=0)
+        p_val = _sigmoid(z_val)
+        thr, _, _, _ = _pick_threshold_for_f1(y_val.to_numpy(), p_val)
+        self.betas_ = betas
+        self.threshold_ = thr
+        return self
+
+    def predict_proba(self, X: pd.DataFrame) -> np.ndarray:
+        if self.betas_ is None:
+            raise RuntimeError("Call fit() first")
+        M = _build_rule_matrix(self.rules_df, X)
+        z = (self.betas_.reshape(-1, 1) * M).sum(axis=0)
+        return _sigmoid(z)
+
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        if self.threshold_ is None:
+            raise RuntimeError("Call fit() first")
+        p = self.predict_proba(X)
+        return (p >= self.threshold_).astype(int)
+
+    def evaluate(self, X: pd.DataFrame, y: pd.Series) -> dict:
+        p = self.predict_proba(X)
+        y_hat = (p >= self.threshold_).astype(int)
+        out = {
+            "precision": precision_score(y, y_hat, zero_division=0),
+            "recall": recall_score(y, y_hat, zero_division=0),
+            "f1": f1_score(y, y_hat, zero_division=0),
+        }
+        try:
+            out["auc_roc"] = roc_auc_score(y, p)
+            out["ap"] = average_precision_score(y, p)
+        except Exception:
+            pass
+        return out
+
+
+class LearnedRulesetClassifier:
+    """Sparse logistic regression over rule indicators."""
+
+    def __init__(self, rules_df: pd.DataFrame, Cs=(0.01, 0.1, 1, 10), l1_ratios=(0.5, 1.0)):
+        self.rules_df = rules_df.copy().reset_index(drop=True)
+        self.Cs = Cs
+        self.l1_ratios = l1_ratios
+        self.coef_: Optional[np.ndarray] = None
+        self.intercept_: float = 0.0
+        self.threshold_: Optional[float] = None
+
+    def fit(self, X_train: pd.DataFrame, y_train: pd.Series, X_val: pd.DataFrame, y_val: pd.Series) -> "LearnedRulesetClassifier":
+        M_train = _build_rule_matrix(self.rules_df, X_train).T
+        lr = LogisticRegressionCV(
+            Cs=self.Cs,
+            cv=5,
+            penalty="elasticnet",
+            solver="saga",
+            l1_ratios=self.l1_ratios,
+            scoring="f1",
+            max_iter=5000,
+            n_jobs=-1,
+            refit=True,
+        )
+        lr.fit(M_train, y_train.to_numpy())
+        self.coef_ = lr.coef_.ravel()
+        self.intercept_ = float(lr.intercept_.ravel()[0])
+        p_val = self.predict_proba(X_val)
+        thr, _, _, _ = _pick_threshold_for_f1(y_val.to_numpy(), p_val)
+        self.threshold_ = thr
+        return self
+
+    def _logit(self, X: pd.DataFrame) -> np.ndarray:
+        if self.coef_ is None:
+            raise RuntimeError("Call fit() first")
+        M = _build_rule_matrix(self.rules_df, X).T
+        return M @ self.coef_ + self.intercept_
+
+    def predict_proba(self, X: pd.DataFrame) -> np.ndarray:
+        return _sigmoid(self._logit(X))
+
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        if self.threshold_ is None:
+            raise RuntimeError("Call fit() first")
+        p = self.predict_proba(X)
+        return (p >= self.threshold_).astype(int)
+
+    def evaluate(self, X: pd.DataFrame, y: pd.Series) -> dict:
+        p = self.predict_proba(X)
+        y_hat = (p >= self.threshold_).astype(int)
+        out = {
+            "precision": precision_score(y, y_hat, zero_division=0),
+            "recall": recall_score(y, y_hat, zero_division=0),
+            "f1": f1_score(y, y_hat, zero_division=0),
+        }
+        try:
+            out["auc_roc"] = roc_auc_score(y, p)
+            out["ap"] = average_precision_score(y, p)
+        except Exception:
+            pass
+        return out

--- a/pm_rules/config.py
+++ b/pm_rules/config.py
@@ -1,0 +1,12 @@
+"""Configuration constants for rule extraction and evaluation."""
+
+TOP_K_FEATURES_PER_INSTANCE = 3
+MIN_SUPPORT = 15
+MIN_PRECISION = 0.90
+MIN_RECALL = 0.15
+MIN_F1 = 0.50
+POS_LABEL = 1
+RANDOM_STATE = 42
+TEST_SIZE = 0.25
+VAL_SIZE = 0.25
+PLOT_RULE_PERFORMANCE = False

--- a/pm_rules/data.py
+++ b/pm_rules/data.py
@@ -1,0 +1,22 @@
+"""Utilities for loading datasets used in examples."""
+
+from typing import Tuple
+import pandas as pd
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+from .config import RANDOM_STATE, TEST_SIZE, VAL_SIZE
+
+
+def load_breast_cancer_split() -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series, pd.DataFrame, pd.Series]:
+    """Load the breast cancer dataset and return train/val/test splits."""
+    dt = load_breast_cancer()
+    X = pd.DataFrame(dt.data, columns=[c.replace(" ", "_") for c in dt.feature_names])
+    y = pd.Series(dt.target, name="y")
+
+    X_train_full, X_test, y_train_full, y_test = train_test_split(
+        X, y, test_size=TEST_SIZE, random_state=RANDOM_STATE, stratify=y
+    )
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train_full, y_train_full, test_size=VAL_SIZE, random_state=RANDOM_STATE, stratify=y_train_full
+    )
+    return X_train, X_val, X_test, y_train, y_val, y_test

--- a/pm_rules/fsrs.py
+++ b/pm_rules/fsrs.py
@@ -1,0 +1,188 @@
+"""Forward Sequential Rule Selection (FSRS)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict, Tuple, Any
+import numpy as np
+import pandas as pd
+from statsmodels.stats.contingency_tables import mcnemar
+
+from .utils import PathConstraint, rule_to_mask, update_constraint
+
+
+@dataclass
+class AtomicCond:
+    feature: str
+    op: str
+    thr: float
+
+
+def conditions_to_rule_dict(conds: List[AtomicCond]) -> Dict[str, PathConstraint]:
+    rd: Dict[str, PathConstraint] = {}
+    for c in conds:
+        if c.feature not in rd:
+            rd[c.feature] = PathConstraint()
+        rd[c.feature] = update_constraint(rd[c.feature], (c.op, float(c.thr)))
+    return rd
+
+
+def expand_rule_dict_canonically(rule_dict: Dict[str, PathConstraint]) -> List[AtomicCond]:
+    conds: List[AtomicCond] = []
+    for f in sorted(rule_dict.keys()):
+        pc = rule_dict[f]
+        if np.isfinite(pc.low):
+            conds.append(AtomicCond(f, "gt", float(pc.low)))
+        if np.isfinite(pc.high):
+            conds.append(AtomicCond(f, "le", float(pc.high)))
+    return conds
+
+
+def rule_row_to_ordered_conditions(rule_row: pd.Series) -> List[AtomicCond]:
+    if "cond_list" in rule_row and isinstance(rule_row["cond_list"], list):
+        return [AtomicCond(c["feature"], c["op"], float(c["thr"])) for c in rule_row["cond_list"]]
+    return expand_rule_dict_canonically(rule_row.get("rule_dict", {}))
+
+
+def apply_prefix_mask(conds: List[AtomicCond], X: pd.DataFrame, prefix_len: int) -> np.ndarray:
+    if prefix_len == 0:
+        return np.ones(len(X), dtype=bool)
+    rd = conditions_to_rule_dict(conds[:prefix_len])
+    return rule_to_mask(rd, X)
+
+
+def estimate_class_prob_for_mask(mask: np.ndarray, y: pd.Series, class_label: int) -> float:
+    if mask.sum() == 0:
+        return 0.0
+    return float((y[mask] == class_label).mean())
+
+
+def majority_label_on_mask(mask: np.ndarray, y: pd.Series, pos_label: int = 1) -> int:
+    if mask.sum() == 0:
+        return pos_label
+    mean_pos = float((y[mask] == pos_label).mean())
+    return pos_label if mean_pos >= 0.5 else 1 - pos_label
+
+
+def mcnemar_between_prefixes(
+    conds: List[AtomicCond],
+    X: pd.DataFrame,
+    y: pd.Series,
+    pred_label: int,
+    i: int,
+) -> Tuple[float, int, int]:
+    mask_i = apply_prefix_mask(conds, X, i)
+    mask_ip1 = apply_prefix_mask(conds, X, i + 1)
+    yhat_i = np.where(mask_i, pred_label, 1 - pred_label)
+    yhat_ip1 = np.where(mask_ip1, pred_label, 1 - pred_label)
+    b = int(np.sum((yhat_i == y.values) & (yhat_ip1 != y.values)))
+    c = int(np.sum((yhat_i != y.values) & (yhat_ip1 == y.values)))
+    table = [[0, b], [c, 0]]
+    res = mcnemar(table, exact=(b + c) < 25, correction=(b + c) >= 25)
+    return float(res.pvalue), b, c
+
+
+def forward_sequential_rule_selection(
+    conds: List[AtomicCond],
+    X: pd.DataFrame,
+    y: pd.Series,
+    pos_label: int = 1,
+    alpha: float = 0.05,
+    delta: float = 0.10,
+    check_flip: bool = True,
+    min_covered: int = 5,
+    pred_label_strategy: str = "majority_full",
+) -> Dict[str, Any]:
+    k = len(conds)
+    if k == 0:
+        mask_full = np.ones(len(X), dtype=bool)
+        prob_full = estimate_class_prob_for_mask(mask_full, y, pos_label)
+        return {
+            "short_conds": [],
+            "selected_prefix_len": 0,
+            "pvals": [],
+            "prob_full": prob_full,
+            "prob_short": prob_full,
+            "pred_label": pos_label,
+            "coverage_full": int(mask_full.sum()),
+            "coverage_short": int(mask_full.sum()),
+        }
+
+    mask_full = apply_prefix_mask(conds, X, k)
+    coverage_full = int(mask_full.sum())
+    pred_label = majority_label_on_mask(mask_full, y, pos_label) if pred_label_strategy == "majority_full" else pos_label
+    if coverage_full < min_covered:
+        prob_full = estimate_class_prob_for_mask(mask_full, y, pred_label)
+        return {
+            "short_conds": conds,
+            "selected_prefix_len": k,
+            "pvals": [],
+            "prob_full": prob_full,
+            "prob_short": prob_full,
+            "pred_label": pred_label,
+            "coverage_full": coverage_full,
+            "coverage_short": coverage_full,
+        }
+
+    prob_full = estimate_class_prob_for_mask(mask_full, y, pred_label)
+    optimal_idx = 0
+    pval_log: List[Tuple[float, float, int, int]] = []
+
+    for i in range(k):
+        alpha_i = alpha / (k - i)
+        pval, b, c = mcnemar_between_prefixes(conds, X, y, pred_label, i)
+        pval_log.append((pval, alpha_i, b, c))
+
+        mask_short = apply_prefix_mask(conds, X, i + 1)
+        coverage_short = int(mask_short.sum())
+        if coverage_short < min_covered:
+            break
+        prob_short = estimate_class_prob_for_mask(mask_short, y, pred_label)
+        stat_sig = pval < alpha_i
+        prob_close = abs(prob_short - prob_full) < delta
+        flip = (prob_short >= 0.5) != (prob_full >= 0.5)
+        if stat_sig and prob_close and (not check_flip or not flip):
+            optimal_idx = i + 1
+        else:
+            break
+
+    short_conds = conds[:optimal_idx]
+    mask_short_final = apply_prefix_mask(conds, X, optimal_idx)
+    prob_short_final = estimate_class_prob_for_mask(mask_short_final, y, pred_label)
+
+    return {
+        "short_conds": short_conds,
+        "selected_prefix_len": optimal_idx,
+        "pvals": pval_log,
+        "prob_full": prob_full,
+        "prob_short": prob_short_final,
+        "pred_label": pred_label,
+        "coverage_full": coverage_full,
+        "coverage_short": int(mask_short_final.sum()),
+    }
+
+
+def fsrs_shorten_rule_row(
+    rule_row: pd.Series,
+    X_val: pd.DataFrame,
+    y_val: pd.Series,
+    pos_label: int = 1,
+    alpha: float = 0.05,
+    delta: float = 0.10,
+    check_flip: bool = True,
+    min_covered: int = 5,
+    pred_label_strategy: str = "majority_full",
+) -> Tuple[Dict[str, PathConstraint], dict]:
+    conds = rule_row_to_ordered_conditions(rule_row)
+    diag = forward_sequential_rule_selection(
+        conds=conds,
+        X=X_val,
+        y=y_val,
+        pos_label=pos_label,
+        alpha=alpha,
+        delta=delta,
+        check_flip=check_flip,
+        min_covered=min_covered,
+        pred_label_strategy=pred_label_strategy,
+    )
+    new_rule_dict = conditions_to_rule_dict(diag["short_conds"])
+    return new_rule_dict, diag

--- a/pm_rules/plotting.py
+++ b/pm_rules/plotting.py
@@ -1,0 +1,96 @@
+"""Visualization utilities for rule performance."""
+from __future__ import annotations
+
+from typing import Optional
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+
+def _short_rule(s: str, maxlen: int = 60) -> str:
+    return s if len(s) <= maxlen else s[: maxlen - 3] + "..."
+
+
+def _normalize_sizes(values, min_size=30, max_size=220):
+    v = np.asarray(values, dtype=float)
+    if v.size == 0:
+        return v
+    vmin, vmax = np.nanmin(v), np.nanmax(v)
+    if not np.isfinite(vmin) or not np.isfinite(vmax) or vmax == vmin:
+        return np.full_like(v, (min_size + max_size) / 2.0)
+    return min_size + (v - vmin) * (max_size - min_size) / (vmax - vmin)
+
+
+def generate_rules_performance_report(
+    merged: pd.DataFrame,
+    out_pdf: str = "generated_rules_performances.pdf",
+    min_precision: Optional[float] = None,
+    min_recall: Optional[float] = None,
+) -> None:
+    required_cols = {"source", "rule_str", "support", "precision", "recall", "f1"}
+    if not required_cols.issubset(merged.columns):
+        missing = required_cols - set(merged.columns)
+        raise ValueError(f"missing columns: {sorted(missing)}")
+    merged = merged.copy()
+    for col in ["support", "precision", "recall", "f1"]:
+        merged[col] = pd.to_numeric(merged[col], errors="coerce")
+
+    with PdfPages(out_pdf) as pdf:
+        fig1 = plt.figure(figsize=(8, 6))
+        for src in merged["source"].astype(str).unique():
+            sub = merged[merged["source"].astype(str) == src]
+            plt.scatter(
+                sub["recall"],
+                sub["precision"],
+                s=_normalize_sizes(sub["support"]),
+                alpha=0.8,
+                label=str(src),
+            )
+        if min_recall is not None:
+            plt.axvline(min_recall, linestyle="--", alpha=0.6)
+        if min_precision is not None:
+            plt.axhline(min_precision, linestyle="--", alpha=0.6)
+        plt.xlabel("Recall (global coverage)")
+        plt.ylabel("Precision (PPV)")
+        plt.title("Precision vs Recall by Rule")
+        plt.grid(True, linestyle="--", alpha=0.4)
+        plt.legend(title="Source")
+        pdf.savefig(fig1, bbox_inches="tight")
+        plt.close(fig1)
+
+        fig2 = plt.figure(figsize=(8, 6))
+        sc = plt.scatter(
+            merged["support"],
+            merged["f1"],
+            c=merged["precision"],
+            s=_normalize_sizes(merged["support"]),
+            alpha=0.85,
+        )
+        plt.xlabel("Support (covered samples)")
+        plt.ylabel("F1 Score")
+        plt.title("Support vs F1 (color ~ Precision)")
+        cbar = plt.colorbar(sc)
+        cbar.set_label("Precision")
+        plt.grid(True, linestyle="--", alpha=0.4)
+        pdf.savefig(fig2, bbox_inches="tight")
+        plt.close(fig2)
+
+        fig3 = plt.figure(figsize=(8, 6))
+        top = merged.sort_values(["f1", "precision", "support"], ascending=[False, False, False]).head(10)
+        y_pos = np.arange(len(top))
+        labels = [_short_rule(s) for s in top["rule_str"].tolist()]
+        plt.barh(y_pos, top["f1"])
+        plt.yticks(y_pos, labels)
+        plt.gca().invert_yaxis()
+        plt.xlabel("F1 Score")
+        plt.title("Top 10 Rules by F1")
+        for i, (f1, ppv, rec) in enumerate(zip(top["f1"], top["precision"], top["recall"])):
+            plt.text(f1 + 0.01, i, f"P={ppv:.2f}, R={rec:.2f}", va="center")
+        xmax = float(top["f1"].max()) if len(top) else 1.0
+        plt.xlim(0, max(1.0, xmax + 0.1))
+        plt.grid(True, axis="x", linestyle="--", alpha=0.3)
+        pdf.savefig(fig3, bbox_inches="tight")
+        plt.close(fig3)
+
+    print(f"Saved plots to: {out_pdf}")

--- a/pm_rules/rule_generation.py
+++ b/pm_rules/rule_generation.py
@@ -1,0 +1,234 @@
+"""Rule extraction utilities for LightGBM models."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass
+import numpy as np
+import pandas as pd
+import lightgbm as lgb
+import shap
+
+from .config import (
+    TOP_K_FEATURES_PER_INSTANCE,
+    MIN_SUPPORT,
+    MIN_PRECISION,
+    MIN_RECALL,
+    MIN_F1,
+    POS_LABEL,
+)
+from .utils import (
+    PathConstraint,
+    update_constraint,
+    rule_to_mask,
+    rule_to_string,
+    rule_recall_global,
+    f1_from_pr,
+)
+
+
+BoosterDump = Dict[str, Any]
+
+
+def load_trees_dump(model: lgb.LGBMClassifier) -> BoosterDump:
+    """Return LightGBM booster dump."""
+    booster = model.booster_
+    return booster.dump_model()
+
+
+def traverse_tree_for_row(
+    tree: Dict[str, Any], row: pd.Series, feat_idx_to_name: Dict[int, str]
+) -> Tuple[List[Tuple[str, Tuple[str, float]]], float]:
+    """Return path followed by a row and leaf value."""
+    path = []
+    node = tree
+    while "split_feature" in node:
+        f_idx = node["split_feature"]
+        f_name = feat_idx_to_name[f_idx]
+        thr = node["threshold"]
+        if row[f_name] <= float(thr):
+            path.append((f_name, ("le", float(thr))))
+            node = node["left_child"]
+        else:
+            path.append((f_name, ("gt", float(thr))))
+            node = node["right_child"]
+    return path, float(node.get("leaf_value", 0.0))
+
+
+def build_rule_from_paths(
+    paths: List[Tuple[str, Tuple[str, float]]], keep_features: set
+) -> Dict[str, PathConstraint]:
+    """Merge path conditions into feature intervals."""
+    rule: Dict[str, PathConstraint] = {}
+    for f_name, (op, thr) in paths:
+        if f_name not in keep_features:
+            continue
+        if f_name not in rule:
+            rule[f_name] = PathConstraint()
+        rule[f_name] = update_constraint(rule[f_name], (op, thr))
+    return rule
+
+
+def extract_local_rules(
+    clf: lgb.LGBMClassifier,
+    X_val: pd.DataFrame,
+    y_val: pd.Series,
+) -> pd.DataFrame:
+    """Generate rules by tracing SHAP-important paths for positives."""
+    explainer = shap.TreeExplainer(clf)
+    shap_vals = explainer.shap_values(X_val)
+    if isinstance(shap_vals, list):  # binary format
+        shap_vals = shap_vals[1]
+    shap_abs = np.abs(shap_vals)
+
+    y_val_pred = clf.predict(X_val)
+    dump = load_trees_dump(clf)
+    tree_infos = dump["tree_info"]
+    feat_idx_to_name = {i: n for i, n in enumerate(X_val.columns)}
+
+    Xv = X_val.reset_index(drop=True)
+    yv = y_val.reset_index(drop=True)
+    yv_pred = pd.Series(y_val_pred).reset_index(drop=True)
+
+    candidates: List[Dict[str, Any]] = []
+
+    for i in range(len(Xv)):
+        if not (yv[i] == POS_LABEL and yv_pred[i] == POS_LABEL):
+            continue
+        row = Xv.iloc[i]
+        shap_order = np.argsort(-shap_abs[i])[:TOP_K_FEATURES_PER_INSTANCE]
+        keep_feats = set(Xv.columns[j] for j in shap_order)
+
+        all_conditions: List[Tuple[str, Tuple[str, float]]] = []
+        for t in tree_infos:
+            tree = t["tree_structure"]
+            path, _ = traverse_tree_for_row(tree, row, feat_idx_to_name)
+            all_conditions.extend(path)
+
+        rule_dict = build_rule_from_paths(all_conditions, keep_feats)
+        if not rule_dict:
+            continue
+
+        mask = rule_to_mask(rule_dict, Xv)
+        support = int(mask.sum())
+        if support < MIN_SUPPORT:
+            continue
+        ppv = float((yv[mask] == POS_LABEL).mean())
+        rec = rule_recall_global(mask, yv, POS_LABEL)
+        f1 = f1_from_pr(ppv, rec)
+        if (ppv < MIN_PRECISION) or (rec < MIN_RECALL) or (f1 < MIN_F1):
+            continue
+
+        candidates.append(
+            {
+                "source": "TreeSHAPLocal",
+                "instance_idx": i,
+                "rule_dict": rule_dict,
+                "rule_str": rule_to_string(rule_dict),
+                "features": list(rule_dict.keys()),
+                "support": support,
+                "precision": ppv,
+                "recall": rec,
+                "f1": f1,
+            }
+        )
+
+    df = pd.DataFrame(candidates)
+    if not df.empty:
+        df = df.sort_values(["f1", "precision", "support"], ascending=[False, False, False])
+        df = df.drop_duplicates(subset=["rule_str"]).reset_index(drop=True)
+    return df
+
+
+def dfs_collect_paths(
+    node: Dict[str, Any],
+    feat_idx_to_name: Dict[int, str],
+    acc_path: List[Tuple[str, Tuple[str, float]]],
+    out_paths: List[Tuple[List[Tuple[str, Tuple[str, float]]], float]],
+) -> None:
+    """Depth-first traversal collecting root-to-leaf paths."""
+    if "split_feature" not in node:
+        leaf_value = float(node.get("leaf_value", 0.0))
+        out_paths.append((acc_path.copy(), leaf_value))
+        return
+    f_idx = node["split_feature"]
+    f_name = feat_idx_to_name[f_idx]
+    thr = float(node["threshold"])
+
+    acc_path.append((f_name, ("le", thr)))
+    dfs_collect_paths(node["left_child"], feat_idx_to_name, acc_path, out_paths)
+    acc_path.pop()
+
+    acc_path.append((f_name, ("gt", thr)))
+    dfs_collect_paths(node["right_child"], feat_idx_to_name, acc_path, out_paths)
+    acc_path.pop()
+
+
+def build_interval_rule_from_path(path: List[Tuple[str, Tuple[str, float]]]) -> Dict[str, PathConstraint]:
+    rule: Dict[str, PathConstraint] = {}
+    for f_name, (op, thr) in path:
+        if f_name not in rule:
+            rule[f_name] = PathConstraint()
+        rule[f_name] = update_constraint(rule[f_name], (op, thr))
+    return rule
+
+
+def extract_global_rules(
+    clf: lgb.LGBMClassifier,
+    X_val: pd.DataFrame,
+    y_val: pd.Series,
+) -> pd.DataFrame:
+    """Mine rules by enumerating all positive leaf paths."""
+    dump = load_trees_dump(clf)
+    tree_infos = dump["tree_info"]
+    feat_idx_to_name = {i: n for i, n in enumerate(X_val.columns)}
+
+    Xv = X_val.reset_index(drop=True)
+    yv = y_val.reset_index(drop=True)
+
+    candidates: List[Dict[str, Any]] = []
+    for t in tree_infos:
+        tree = t["tree_structure"]
+        paths: List[Tuple[List[Tuple[str, Tuple[str, float]]], float]] = []
+        dfs_collect_paths(tree, feat_idx_to_name, [], paths)
+        for path_conditions, leaf_val in paths:
+            if leaf_val <= 0.0:
+                continue
+            rule_dict = build_interval_rule_from_path(path_conditions)
+            mask = rule_to_mask(rule_dict, Xv)
+            support = int(mask.sum())
+            if support < MIN_SUPPORT:
+                continue
+            ppv = float((yv[mask] == POS_LABEL).mean())
+            rec = rule_recall_global(mask, yv, POS_LABEL)
+            f1 = f1_from_pr(ppv, rec)
+            if (ppv < MIN_PRECISION) or (rec < MIN_RECALL) or (f1 < MIN_F1):
+                continue
+            candidates.append(
+                {
+                    "source": "GlobalPath",
+                    "rule_dict": rule_dict,
+                    "rule_str": rule_to_string(rule_dict),
+                    "features": list(rule_dict.keys()),
+                    "support": support,
+                    "precision": ppv,
+                    "recall": rec,
+                    "f1": f1,
+                    "leaf_value": leaf_val,
+                }
+            )
+    df = pd.DataFrame(candidates)
+    if not df.empty:
+        df = df.sort_values(["f1", "precision", "support"], ascending=[False, False, False])
+        df = df.drop_duplicates(subset=["rule_str"]).reset_index(drop=True)
+    return df
+
+
+def merge_rule_sets(local_df: pd.DataFrame, global_df: pd.DataFrame) -> pd.DataFrame:
+    """Combine local and global candidate rules."""
+    frames = [df for df in [local_df, global_df] if df is not None and not df.empty]
+    if not frames:
+        return pd.DataFrame()
+    merged = pd.concat(frames, ignore_index=True)
+    merged = merged.sort_values(["f1", "precision", "support"], ascending=[False, False, False])
+    merged = merged.drop_duplicates(subset=["rule_str"]).reset_index(drop=True)
+    return merged

--- a/pm_rules/utils.py
+++ b/pm_rules/utils.py
@@ -1,0 +1,53 @@
+"""Common utilities for rule construction and evaluation."""
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class PathConstraint:
+    """Interval constraints for a single feature."""
+    low: float = -np.inf
+    high: float = np.inf
+
+
+def update_constraint(cons: PathConstraint, cond: Tuple[str, float]) -> PathConstraint:
+    """Intersect existing constraint with a new condition."""
+    op, thr = cond
+    if op == "le":
+        cons.high = min(cons.high, thr)
+    elif op == "gt":
+        cons.low = max(cons.low, thr)
+    return cons
+
+
+def rule_to_mask(rule: Dict[str, PathConstraint], X: pd.DataFrame) -> np.ndarray:
+    """Return mask of rows satisfying the rule."""
+    mask = np.ones(len(X), dtype=bool)
+    for f_name, cons in rule.items():
+        mask &= (X[f_name] > cons.low) & (X[f_name] <= cons.high)
+    return mask
+
+
+def rule_to_string(rule: Dict[str, PathConstraint]) -> str:
+    parts = []
+    for f_name, cons in rule.items():
+        if cons.low != -np.inf:
+            parts.append(f"{f_name} > {cons.low:.6g}")
+        if cons.high != np.inf:
+            parts.append(f"{f_name} <= {cons.high:.6g}")
+    return " & ".join(parts) if parts else "(True)"
+
+
+def rule_recall_global(mask: np.ndarray, y_true: pd.Series, pos_label: int = 1) -> float:
+    pos_total = (y_true == pos_label).sum()
+    if pos_total == 0:
+        return 0.0
+    tp = ((mask) & (y_true == pos_label)).sum()
+    return tp / pos_total
+
+
+def f1_from_pr(precision: float, recall: float) -> float:
+    return (2 * precision * recall) / (precision + recall) if (precision + recall) else 0.0


### PR DESCRIPTION
## Summary
- Add `pm_rules` package with configuration, data loading, utilities, rule generation, FSRS, classifiers and plotting modules
- Provide `example_pipeline.py` showing end-to-end rule extraction and voting classifier usage

## Testing
- `python -m py_compile example_pipeline.py pm_rules/*.py`
- Failed: `pip install lightgbm shap statsmodels` (ProxyError: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_6898ce14f94883209e6fb7098f3f44d5